### PR TITLE
fix(ci): pin Wrangler deployment version

### DIFF
--- a/.github/workflows/publish-to-cloudflare-pages.yml
+++ b/.github/workflows/publish-to-cloudflare-pages.yml
@@ -33,4 +33,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: r4ai-dev
           directory: ./dist
+          wranglerVersion: "3.90.0"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/security/wrangler-version.test.mjs
+++ b/scripts/security/wrangler-version.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const workflowUrl = new URL(
+  "../../.github/workflows/publish-to-cloudflare-pages.yml",
+  import.meta.url
+)
+
+test("Cloudflare Pages deployment pins the Wrangler version", async () => {
+  const workflow = await readFile(workflowUrl, "utf8")
+  const wranglerVersion = workflow.match(
+    /wranglerVersion:\s*["']([^"']+)["']/
+  )?.[1]
+
+  assert.match(wranglerVersion ?? "", /^\d+\.\d+\.\d+$/)
+})


### PR DESCRIPTION
## What changed

Pins the Wrangler version used by the Cloudflare Pages action to `3.90.0`.

## Why

The archived Pages action otherwise resolves the mutable `wrangler@2` major range during a credentialed deployment.

## Validation

- `node --test scripts/security/wrangler-version.test.mjs`
- `git diff --check`

The regression test failed before the explicit version was added and passes with the fix.