### PR TITLE
fix(ci): isolate Cloudflare deployment credentials

### DIFF
--- a/.github/workflows/publish-to-cloudflare-pages.yml
+++ b/.github/workflows/publish-to-cloudflare-pages.yml
@@ -10,11 +10,10 @@ on:
       - main
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      deployments: write
     steps:
       - name: Checkout respository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -26,6 +25,32 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build website
         run: pnpm run build
+      - name: Archive build output
+        run: |
+          tar --create --file dist.tar --format=posix dist
+          sha256sum dist.tar >dist.tar.sha256
+      - name: Upload build output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cloudflare-pages-build
+          path: |
+            dist.tar
+            dist.tar.sha256
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      deployments: write
+    steps:
+      - name: Download build output
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cloudflare-pages-build
+      - name: Verify and extract build output
+        run: |
+          sha256sum --check dist.tar.sha256
+          tar --extract --file dist.tar
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
         with:

--- a/scripts/security/publish-job-isolation.test.mjs
+++ b/scripts/security/publish-job-isolation.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const workflowUrl = new URL(
+  "../../.github/workflows/publish-to-cloudflare-pages.yml",
+  import.meta.url
+)
+
+test("Cloudflare credentials are isolated from the build job", async () => {
+  const workflow = await readFile(workflowUrl, "utf8")
+
+  assert.match(workflow, /^ {2}build:/m)
+  assert.match(workflow, /^ {2}deploy:\n {4}needs: build/m)
+
+  const buildStart = workflow.indexOf("  build:")
+  const deployStart = workflow.indexOf("\n  deploy:")
+  const buildJob = workflow.slice(buildStart, deployStart)
+
+  assert.notEqual(buildStart, -1)
+  assert.notEqual(deployStart, -1)
+  assert.doesNotMatch(buildJob, /CLOUDFLARE_|cloudflare\/pages-action/)
+  assert.match(buildJob, /actions\/upload-artifact@[0-9a-f]{40}/)
+
+  const deployJob = workflow.slice(deployStart)
+  assert.match(deployJob, /actions\/download-artifact@[0-9a-f]{40}/)
+  assert.match(deployJob, /sha256sum --check dist\.tar\.sha256/)
+  assert.match(deployJob, /CLOUDFLARE_|cloudflare\/pages-action/)
+})


### PR DESCRIPTION
## What changed

Splits the Cloudflare Pages workflow into an unprivileged build job and a credentialed deploy job. The build output crosses the boundary as a pinned GitHub Actions artifact, is checksum-verified, then extracted for deployment.

## Why

Build-time code previously shared a runner with Cloudflare credentials and could persist environment changes into the credentialed action.

## Validation

- `node --test scripts/security/publish-job-isolation.test.mjs`
- `git diff --check`

The regression test failed before the job boundary existed and passes with the fix.