### PR TITLE
fix(embed): remove video oEmbed HTML injection

### DIFF
--- a/scripts/security/oembed-video-rendering.test.mjs
+++ b/scripts/security/oembed-video-rendering.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const componentUrl = new URL(
+  "../../src/components/ui/embed/oembed-video.tsx",
+  import.meta.url
+)
+
+test("video oEmbed rendering does not inject provider HTML", async () => {
+  const component = await readFile(componentUrl, "utf8")
+
+  assert.doesNotMatch(component, /innerHTML/)
+  assert.doesNotMatch(component, /JSON\.parse\(props\.oEmbed\)/)
+  assert.match(component, /<Link href=\{props\.url\}>\{props\.url\}<\/Link>/)
+})

--- a/src/components/ui/embed/oembed-video.tsx
+++ b/src/components/ui/embed/oembed-video.tsx
@@ -1,5 +1,6 @@
-import type { OEmbedVideo as OEmbedViodeType } from "@r4ai/remark-embed/transformers"
-import { type Component, createMemo } from "solid-js"
+import type { Component } from "solid-js"
+
+import { Link, Paragraph } from "@/components/typography"
 
 export type OEmbedVideoProps = {
   url: string
@@ -8,15 +9,9 @@ export type OEmbedVideoProps = {
 
 // todo: add storybook
 export const OEmbedVideo: Component<OEmbedVideoProps> = (props) => {
-  const oEmbed = createMemo(() => JSON.parse(props.oEmbed) as OEmbedViodeType)
   return (
-    <div
-      class="mx-auto w-full max-w-screen-md *:!h-full *:!w-full"
-      style={{
-        "aspect-ratio": `${oEmbed().width}/${oEmbed().height}`,
-      }}
-      // eslint-disable-next-line solid/no-innerhtml
-      innerHTML={oEmbed().html}
-    />
+    <Paragraph>
+      <Link href={props.url}>{props.url}</Link>
+    </Paragraph>
   )
 }


### PR DESCRIPTION
## What changed

Replaces video oEmbed provider markup with the safe link fallback already used when no oEmbed match is available.

## Why

The remote provider response reached Solid's `innerHTML` sink without a sanitizer or provider allowlist. The new rendering path never parses or inserts provider HTML.

## User impact

Video oEmbed entries remain navigable through their original URL; interactive inline player rendering is intentionally disabled until a typed, provider-specific renderer is introduced.

## Validation

- `node --test scripts/security/oembed-video-rendering.test.mjs`
- `git diff --check`

The regression test failed before removing the raw HTML sink and passes with the fix.