### PR TITLE
perf: skip bundle analysis in regular builds

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -57,10 +57,11 @@ export default defineConfig({
       pagefind(),
       rawTransform(),
       icons({ compiler: "solid" }),
-      visualizer({
-        emitFile: true,
-        filename: "stats.html",
-      }),
+      process.env.ANALYZE === "true" &&
+        visualizer({
+          emitFile: true,
+          filename: "stats.html",
+        }),
     ],
   },
   markdown: {


### PR DESCRIPTION
## Summary

- skip Rollup bundle visualization during regular builds
- preserve the existing `stats.html` report behind `ANALYZE=true`
- keep the change limited to `astro.config.ts`

## Why

The bundle visualization report is not consumed by the site, but generating it adds analysis and serialization work to every production build. Regular builds now avoid that diagnostic-only work while opt-in analysis builds retain the existing report.

## Benchmark

Adjacent GitHub Actions runs on the same runner image and the same `main` base:

- before: Astro built 23 pages in 39.02s
- after: Astro built 23 pages in 33.48s
- improvement: 5.54s faster (about 14%)

This is a single CI comparison and includes normal runner and network variance.

## Validation

- CI safeguards: passed
- type check: passed
- production build: passed
- lint: passed
- format: passed
- Storybook build and VRT comparison: passed
- Cloudflare Pages preview build and deploy: passed
- diff: 1 commit, 1 file
