### PR TITLE
docs: update license copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 rai
+Copyright (c) 2023-2026 rai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update the MIT License copyright year through 2026

## Validation
- `git diff --check`
- pre-commit hooks passed